### PR TITLE
Fix track info selectors

### DIFF
--- a/quickify_content.js
+++ b/quickify_content.js
@@ -42,8 +42,8 @@ Quickify.broadcast = function() {
   const statusMsg = {};
   statusMsg.type = QuickifyMessages.STATUS;
 
-  const trackName = document.querySelector('.track-info .track-info__name a');
-  const trackArtist = document.querySelector('.track-info .track-info__artists a');
+  const trackName = document.querySelector('.Root__now-playing-bar [dir="auto"]:first-child a');
+  const trackArtist = document.querySelector('.Root__now-playing-bar [dir="auto"]:last-child a');
 
   const artCoverUrl = document.querySelector("div.now-playing__cover-art .cover-art-image").style.backgroundImage;
 


### PR DESCRIPTION
The query selectors for current track name and artist are no longer working with the latest Spotify version--`.track-info` does not appear in the version that I am being served. I've updated the query selectors to match the latest version.